### PR TITLE
Ajustes 11 de novembro

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -518,7 +518,7 @@ h1 {
   max-width: 500px;
   margin: 0 auto;
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
 }
 
 .wrong-attempt {
@@ -848,7 +848,7 @@ h1 {
   max-width: 600px;
   margin: 0 auto;
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
 }
 
 .wrong-attempt {

--- a/src/App.css
+++ b/src/App.css
@@ -992,8 +992,8 @@ h1 {
     width: 100%;            /* ocupa a largura da coluna */
     min-width: 90px;        /* combina com minmax da coluna */
     max-width: 110px;       /* mantém tamanho confortável */
-    height: 56px; min-height:56px;
-    font-size:0.8rem; padding:4px;
+    height: 66px; min-height: 66px;
+    font-size: 0.8rem; padding: 4px 2px;
     margin: 0 auto;         /* garante centralização */
   }
   .col-underline { height:4px; width:72%; }
@@ -1004,20 +1004,35 @@ h1 {
   /* Deixa os títulos das colunas ainda mais compactos */
   .col-title-text { font-size: 0.8rem; }
 
-  /* Ajusta o conteúdo textual dentro dos quadrados para não "quebrar" estranho */
-  .attempt-row .attempt-square > div:first-child {
-    font-size: 0.7rem;
-    line-height: 1.1;
+  /* Ajusta o conteúdo textual dentro dos quadrados para quebrar de forma legível */
+  .attempt-text-content {
+    font-size: 0.65rem !important;
+    line-height: 1.15 !important;
     width: 100% !important;
-    max-height: 38px !important;
-    overflow: hidden !important;
-    text-overflow: ellipsis;
-    white-space: nowrap !important; /* mostra uma linha apenas com reticências */
+    max-height: 58px !important; /* limita altura para permitir scroll */
+    overflow-y: auto !important;
+    overflow-x: hidden !important;
+    white-space: normal !important; /* permite quebra de linha */
+    word-break: break-word !important;
   }
 
-  /* Esconde o badge de acerto parcial dentro do quadrado no mobile para caber melhor */
-  .attempt-row .attempt-square > div:nth-child(2) {
-    display: none !important;
+  /* Badge de acerto parcial no mobile - sempre visível mas menor */
+  .partial-match-badge {
+    font-size: 0.65rem !important;
+    padding: 2px 4px !important;
+    top: 2px !important;
+    right: 2px !important;
+  }
+
+  /* Reduz o losango de década no mobile para não quebrar o layout */
+  .decade-arrow {
+    width: 15px !important;
+    height: 15px !important;
+    margin-top: 0.25rem !important;
+  }
+  
+  .decade-arrow svg {
+    font-size: 8px !important;
   }
 
   /* Remove largura mínima dos títulos de coluna no mobile para alinhar com os quadrados */

--- a/src/components/ClassicGame.js
+++ b/src/components/ClassicGame.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { FaPalette, FaPaintBrush, FaMonument, FaChartBar, FaQuestion, FaLightbulb, FaSpinner, FaCalendarAlt, FaFire } from 'react-icons/fa'; 
+import { FaPalette, FaPaintBrush, FaMonument, FaChartBar, FaQuestion, FaLightbulb, FaSpinner, FaCalendarAlt, FaFire, FaArrowDown, FaArrowUp } from 'react-icons/fa';
 import Select from 'react-select';
 import { fillPossibleValues, getAllPossibleValues, getArtProperties } from '../util/ClassicModeDataFetch.js';
 import obraExemplo from '../assets/obra_exemplo.jpg';
@@ -443,10 +443,20 @@ const ClassicGame = ({ loadingArt, loadingOptions }) => {
             {properties.map((field) => {
               const value = attempt[field.property] || '';
               const valueAsString = (!value || (Array.isArray(value) && value.length === 0)) ? '-' : value.join(", ");
-              const correct = checkCorrect(field.property, value);
+                const correct = checkCorrect(field.property, value);
               const partiallyCorrect = checkPartiallyCorrect(field.property, value);
+              
+              // Verifica se precisa mostrar seta de década
+              const isDecadeField = field.property === "data-da-obra-2";
+              const showArrow = isDecadeField && answer && answer[field.property] && !correct && value && value.length > 0;
+              const arrowDirection = showArrow && value[0] > answer[field.property][0] ? 'down' : 'up';
+              
+              // Verifica se tem múltiplos valores corretos (mostra badge mesmo quando acerta)
+              const hasMultipleValues = answer && answer[field.property] && answer[field.property].length > 1;
+              const showBadge = hasMultipleValues && partiallyCorrect;
+              
               return (
-                <div key={field.property} className={`attempt-square ${correct ? 'correct' : (partiallyCorrect ? 'partially' : 'wrong')}`} 
+                <div key={field.property} className={`attempt-square ${correct ? 'correct' : (partiallyCorrect ? 'partially' : 'wrong')}`}
                   style={{
                     padding: '0.75rem',
                     textAlign: 'center',
@@ -455,35 +465,70 @@ const ClassicGame = ({ loadingArt, loadingOptions }) => {
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
-                    wordBreak: 'break-word'
+                    wordBreak: 'break-word',
+                    position: 'relative',
+                    flexDirection: showArrow ? 'column' : 'row',
+                    gap: showArrow ? '0.25rem' : '0'
                   }}
                   title={`${field.label}: ${valueAsString}`}>
-                  <div style={{
-                    width: '70%',
+                  
+                  {/* Badge de acerto parcial - posicionado no topo direito */}
+                  {showBadge && (
+                    <div className="partial-match-badge" style={{
+                      position: 'absolute',
+                      top: '4px',
+                      right: '4px',
+                      fontWeight: 'bold',
+                      backgroundColor: correct ? '#4caf50' : '#ff8800ff',
+                      padding: '3px 6px',
+                      borderRadius: '3px',
+                      color: correct ? '#fff' : '#000000ff',
+                      fontSize: '0.75rem',
+                      lineHeight: '1',
+                      boxShadow: '0 1px 3px rgba(0,0,0,0.2)'
+                    }}>{partiallyCorrectTips(field.property, value)}</div>
+                  )}
+                  
+                  <div className="attempt-text-content" style={{
+                    width: showArrow ? '100%' : (showBadge ? '100%' : '70%'),
                     wordBreak: 'break-word',
-                    overflowY: 'scroll',
+                    overflowY: 'auto',
                     whiteSpace: 'normal',
-                    maxHeight: '50px'
+                    maxHeight: showArrow ? '40px' : '50px',
+                    textAlign: 'center',
+                    paddingRight: showBadge ? '35px' : '0'
                   }}>
                     {valueAsString}
                   </div>
-                  {(!correct && partiallyCorrect) && (
-                    <div style={{
-                      fontWeight: 'bold',
-                      margin: '10px',
-                      backgroundColor: '#ff8800ff',
-                      padding: '5px',
-                      borderRadius: '3px',
-                      color: '#000000ff'
-                    }}>{partiallyCorrectTips(field.property, value)}</div>
-                  )}
-                  {field.property == "data-da-obra-2" && answer && answer[field.property] && ( 
-                    <div>
-                      {value[0] > answer[field.property][0] && (
-                        <span style={{ marginLeft: '6px', color: '#2196f3', fontSize: '1.2em' }}>&darr;</span>
-                      )}
-                      {value[0] < answer[field.property][0] && (
-                        <span style={{ marginLeft: '6px', color: '#2196f3', fontSize: '1.2em' }}>&uarr;</span>
+                  
+                  {/* Seta de década estilo LoLdle */}
+                  {showArrow && (
+                    <div className="decade-arrow" style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: '26px',
+                      height: '26px',
+                      borderRadius: '4px',
+                      background: '#005285',
+                      transform: 'rotate(45deg)',
+                      boxShadow: '0 3px 8px rgba(0, 82, 133, 0.4)',
+                      marginTop: '0.4rem'
+                    }}>
+                      {arrowDirection === 'down' ? (
+                        <FaArrowDown style={{ 
+                          color: '#fff', 
+                          fontSize: '11px', 
+                          transform: 'rotate(-45deg)',
+                          fontWeight: 'bold'
+                        }} />
+                      ) : (
+                        <FaArrowUp style={{ 
+                          color: '#fff', 
+                          fontSize: '11px', 
+                          transform: 'rotate(-45deg)',
+                          fontWeight: 'bold'
+                        }} />
                       )}
                     </div>
                   )}

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,7 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 const Home = () => {
+  /* CÓDIGO COMENTADO - Disclaimer/Aviso Mobile (removido temporariamente)
+   * Descomente caso queira reativar o pop-up de aviso para dispositivos móveis
+   * 
   const [showMobileWarning, setShowMobileWarning] = useState(false);
 
   useEffect(() => {
@@ -18,10 +21,11 @@ const Home = () => {
   const handleCloseWarning = () => {
     setShowMobileWarning(false);
   };
+  */
 
   return (
     <div className="content">
-      {/* Pop-up de aviso para mobile */}
+      {/* MODAL DE AVISO MOBILE - COMENTADO
       {showMobileWarning && (
         <div className="tutorial-modal-overlay">
           <div 
@@ -99,6 +103,7 @@ const Home = () => {
           </div>
         </div>
       )}
+      FIM DO MODAL DE AVISO MOBILE */}
 
       <header className="header">
         <div className="title-box">

--- a/src/components/MuralGame.js
+++ b/src/components/MuralGame.js
@@ -113,17 +113,21 @@ const MuralGame = ({ loadingArt }) => {
 
   const selectOptions = useMemo(
     () =>
-      allMuralTitles.map((title) => ({
-        value: title,
-        label: title,
-      })),
-    [allMuralTitles]
+      allMuralTitles
+        .filter((title) => !attempts.includes(title)) // Remove tentativas já feitas
+        .map((title) => ({
+          value: title,
+          label: title,
+        })),
+    [allMuralTitles, attempts]
   );
 
   const filterOptionByPrefix = (option, inputValue) => {
+    // Se não digitou nada, mostra todas as opções
     if (inputValue === '') {
-      return false;
+      return true;
     }
+    // Se digitou algo, filtra por prefixo
     return option.label.toLowerCase().startsWith(inputValue.toLowerCase());
   };
 

--- a/src/components/SculptureGame.js
+++ b/src/components/SculptureGame.js
@@ -75,11 +75,13 @@ const SculptureGame = ({ loadingArt }) => {
 
   const selectOptions = useMemo(
     () =>
-      allSculptureTitles.map((title) => ({
-        value: title,
-        label: title,
-      })),
-    [allSculptureTitles]
+      allSculptureTitles
+        .filter((title) => !attempts.includes(title)) // Remove tentativas já feitas
+        .map((title) => ({
+          value: title,
+          label: title,
+        })),
+    [allSculptureTitles, attempts]
   );
 
   const handleSubmit = (e) => {
@@ -102,9 +104,11 @@ const SculptureGame = ({ loadingArt }) => {
   };
 
   const filterOptionByPrefix = (option, inputValue) => {
+    // Se não digitou nada, mostra todas as opções
     if (inputValue === '') {
-      return false;
+      return true;
     }
+    // Se digitou algo, filtra por prefixo
     return option.label.toLowerCase().startsWith(inputValue.toLowerCase());
   };
 


### PR DESCRIPTION
Coisas que ajeitei:

- Depois de fazer uma tentativa, ela não pode mais ficar disponível para ser chutada (acho que também somente nos modos de mural e escultura, acho que já está arrumado no modo clássico)

- mudar ordem do display das tentativas no modo de escultura e mural, atualmente ta mostrando o mais antigo e depois os mais recentes. E tem que ser o contrário: os mais recentes no topo

-ah, também as setinhas la da decada do modo classico (Fiz oq pude com minhas noçoes artisticas horriveis e o copilot kkkk)

- tirar aquele aviso que aparece quando entra-se no site pela primeira vez de tipo: use no pc pois ainda não foi adaptado ainda pra mobile (Tirei isso)

- [11/11/2025 09:10] Andriel Prieto: que a pessoa só clicou nos inputs e n abriu nada pq ele n digitou nada
  [11/11/2025 09:11] Andriel Prieto: de fato é bem antipratico esse negócio de só aparecer se digitar
  [11/11/2025 09:11] Andriel Prieto: na pratica acabo chutando todas as letras pra ver o que aparece kkk

 Ajeitei isso aí acima.